### PR TITLE
Disable release profile; add LLVM tools to Dockerfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ jsonwebtoken = "9.3"
 futures-util = "0.3"
 derive_more = "0.99"
 
-[profile.release]
-opt-level = 3
-lto = "fat"  # or "thin" for faster build times with less optimization
-debug = false
-codegen-units = 1
-panic = 'abort'
+#[profile.release]
+#opt-level = 3
+#lto = "fat"  # or "thin" for faster build times with less optimization
+#debug = false
+#codegen-units = 1
+#panic = 'abort'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ RUN apk update && apk add --no-cache \
     openssl-dev \
     musl-dev \
     pkgconfig \
-    build-base
+    build-base \
+    clang \
+    clang-dev \
+    llvm \
+    llvm-dev
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
Commented out the release profile settings in Cargo.toml to ensure defaults are used. Updated the Dockerfile to include clang, clang-dev, llvm, and llvm-dev for enhanced development and build support.